### PR TITLE
fix resolved path on Windows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ export function ngcPlugin(options?: Options) {
     resolveId: resolver(),
     transform(code: string, id: string) {
       if (!id.includes('node_modules')) {
-        return compile({ id: resolve(id), host, options: opts, files })
+        return compile({ id: resolve(id).replace(/\\/g, '/'), host, options: opts, files })
       }
       return optimizer(code, id, { 
         sideEffectFreeModules,


### PR DESCRIPTION
I was wondering why it never compiled anything on windows (empty file), and after looking at the code, it turns out that you use the file path as a key into the Map containing the files, but Angular has normalized paths on Windows, and the `fileName` that is returned by the compiler host contains forward slashes, while the id returned by rollup is OS-dependent with back slashes on Windows... that's why the compile function never found any file to compile, it was using the wrong key to look into the map.
I fixed the resolved path for the id so that it would work correctly on Windows, and now it compiles correctly !

Fixes https://github.com/aelbore/ngx-elements/issues/10